### PR TITLE
Add `types` to `exports` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "exports": {
     ".": {
       "import": "./dist/react-use-print.es.js",
-      "require": "./dist/react-use-print.umd.js"
+      "require": "./dist/react-use-print.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
When using your package in our (module) project, I get the following error:
```
Could not find a declaration file for module 'react-use-print'. '/node_modules/react-use-print/dist/react-use-print.es.js' implicitly has an 'any' type.
There are types at '/node_modules/react-use-print/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-use-print' library may need to update its package.json or typings.
```
This can be resolved by adding the typing information to the exports property in the package.json.